### PR TITLE
Add D-CoDe (EMNLP 2025) to Training-free Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ If you find our survey useful for your research, please cite the following paper
 | [**SlowFast-LLaVA: A Strong Training-Free Baseline for Video Large Language Models**](https://arxiv.org/abs/2407.15841) |   SlowFast-LLaVA    | 07/2024 |  -   | arXiv |
 | [**TS-LLaVA: Constructing Visual Tokens through Thumbnail-and-Sampling for Training-Free Video Large Language Models**](https://arxiv.org/abs/2411.11066) | TS-LLaVA | 11/2024 | [code](https://github.com/tingyu215/TS-LLaVA) | arXiv |
 | [**Can Sound Replace Vision in LLaVA With Token Substitution?**](https://arxiv.org/pdf/2506.10416) | SoundCLIP | 08/2025 | [code](https://github.com/ali-vosoughi/SoundCLIP) | arXiv |
+| [**D-CoDe: Scaling Image-Pretrained VLMs to Video via Dynamic Compression and Question Decomposition**](https://aclanthology.org/2025.emnlp-main.597/) [![Star](https://img.shields.io/github/stars/hukcc/D-CoDe.svg?style=social&label=Star)](https://github.com/hukcc/D-CoDe) | D-CoDe | 08/2025 | [code](https://github.com/hukcc/D-CoDe) [project page](https://hukcc.github.io/D-CoDe/) | EMNLP |
 
 ---
 


### PR DESCRIPTION
Hi, thanks for maintaining this great list!

I'd like to add our EMNLP 2025 paper **D-CoDe** to the Training-free Methods section.

- **Paper**: [D-CoDe: Scaling Image-Pretrained VLMs to Video via Dynamic Compression and Question Decomposition](https://aclanthology.org/2025.emnlp-main.597/)
- **Code**: https://github.com/hukcc/D-CoDe

D-CoDe is a training-free adaptation framework that extends image-pretrained VLMs to video understanding via dynamic compression and question decomposition.

Thanks for your review!